### PR TITLE
【Task. 9-5 既存 API の修正】

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,8 @@
 module Api::V1
   # base_api_controller を継承
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy] # 2/15 追記
+
     def index
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,9 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user = User.first
-  end
+  # def current_user
+  #   @current_user = User.first
+  # end
+  # 以下 2/15 追記
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -12,7 +12,7 @@ RSpec/AnyInstance:
 # パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
-  Max: 4
+  Max: 8 # 2/15 追記
 
 # 日本語だと「〜の場合」になるので suffix でないと対応できない
 RSpec/ContextWording:

--- a/log/test.log
+++ b/log/test.log
@@ -11079,3 +11079,720 @@ Processing by DeviseTokenAuth::SessionsController#destroy as HTML
 [active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.05ms)
 Completed 404 Not Found in 1ms (Views: 0.2ms | ActiveRecord: 0.0ms | Allocations: 368)
   [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[35m (0.7ms)[0m  [1m[34mSELECT "ar_internal_metadata"."value" FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1[0m  [["key", "schema_sha1"]]
+  [1m[35m (0.6ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (2.8ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "2_margarette@koch.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (1.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."email" IS NULL AND "users"."provider" = $1 LIMIT $2[0m  [["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (1.7ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."email" IS NULL AND "users"."provider" = $1 LIMIT $2[0m  [["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "3_joni@gibson-bergnaum.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "4_thuy@franecki-beier.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (2.0ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "4_thuy@franecki-beier.test"], ["encrypted_password", "$2a$12$emFqgAiNYd1hQSs0uOM2A.KBUrmqem5pvk8NYUyxLrv11y/.7ST4i"], ["name", "t4ct8v57qsflua31454ea"], ["email", "4_thuy@franecki-beier.test"], ["created_at", "2024-02-15 02:56:16.757722"], ["updated_at", "2024-02-15 02:56:16.757722"]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (4.4ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "礎"], ["body", "右利きはなじかんどうするじじょでん。"], ["user_id", 33], ["created_at", "2024-02-15 02:56:16.761981"], ["updated_at", "2024-02-14 02:56:16.467718"]]
+  [1m[36mTRANSACTION (1.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "5_damien@terry.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.0ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "5_damien@terry.example"], ["encrypted_password", "$2a$12$.s/5QdwIqFQfSxHW/psfXuj.XqpRmSXYCyHZesBO0dZWbnUmdi8Y2"], ["name", "q"], ["email", "5_damien@terry.example"], ["created_at", "2024-02-15 02:56:17.190833"], ["updated_at", "2024-02-15 02:56:17.190833"]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.0ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "せいしん"], ["body", "病床こくみんこいぬ金星。"], ["user_id", 34], ["created_at", "2024-02-15 02:56:17.193149"], ["updated_at", "2024-02-13 02:56:16.768953"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "6_ellis.mcdermott@funk.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.3ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "6_ellis.mcdermott@funk.test"], ["encrypted_password", "$2a$12$.d61w4omJ5hSK6XVvwRby.S3m/ZpMnXWwnsH76iVm2tf5zMUOPauG"], ["name", "eugklurthpt8ym0ovs2al"], ["email", "6_ellis.mcdermott@funk.test"], ["created_at", "2024-02-15 02:56:17.544343"], ["updated_at", "2024-02-15 02:56:17.544343"]]
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.8ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (2.2ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "むぜい"], ["body", "泳ぐかいぞく擬装ねんじゅう。"], ["user_id", 35], ["created_at", "2024-02-15 02:56:17.547052"], ["updated_at", "2024-02-15 02:56:17.547052"]]
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/articles" for 127.0.0.1 at 2024-02-15 11:56:17 +0900
+Processing by Api::V1::ArticlesController#index as HTML
+  [1m[36mArticle Load (1.0ms)[0m  [1m[34mSELECT "articles".* FROM "articles" ORDER BY "articles"."updated_at" DESC[0m
+[active_model_serializers]   [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 35], ["LIMIT", 1]]
+[active_model_serializers]   [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 33], ["LIMIT", 1]]
+[active_model_serializers]   [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 34], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::Attributes (6.84ms)
+Completed 200 OK in 16ms (Views: 8.7ms | ActiveRecord: 2.4ms | Allocations: 6834)
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.8ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (2.5ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "7_timothy@crona.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.7ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "7_timothy@crona.test"], ["encrypted_password", "$2a$12$sziuYVgviW7AXfFCnaVsse1kt72iypyOgr8MFfZguTE8.745KUq2i"], ["name", "rky"], ["email", "7_timothy@crona.test"], ["created_at", "2024-02-15 02:56:17.887665"], ["updated_at", "2024-02-15 02:56:17.887665"]]
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.3ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "たいこうする"], ["body", "さいばん俵はちのすしょうかする。"], ["user_id", 36], ["created_at", "2024-02-15 02:56:17.890842"], ["updated_at", "2024-02-15 02:56:17.890842"]]
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/articles/4" for 127.0.0.1 at 2024-02-15 11:56:17 +0900
+Processing by Api::V1::ArticlesController#show as HTML
+  Parameters: {"id"=>"4"}
+  [1m[36mArticle Load (1.8ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+[active_model_serializers]   [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 36], ["LIMIT", 1]]
+[active_model_serializers] Rendered Api::V1::ArticleSerializer with ActiveModelSerializers::Adapter::Attributes (2.11ms)
+Completed 200 OK in 29ms (Views: 1.2ms | ActiveRecord: 3.2ms | Allocations: 1677)
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mBEGIN[0m
+Started GET "/api/v1/articles/10000" for 127.0.0.1 at 2024-02-15 11:56:17 +0900
+Processing by Api::V1::ArticlesController#show as HTML
+  Parameters: {"id"=>"10000"}
+  [1m[36mArticle Load (0.8ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 10000], ["LIMIT", 1]]
+Completed 404 Not Found in 1ms (ActiveRecord: 0.8ms | Allocations: 448)
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "8_vance.jakubowski@bradtke.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.6ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "8_vance.jakubowski@bradtke.example"], ["encrypted_password", "$2a$12$5nEaNAcPVleNEUegAOKgyOzbko3jEwPrBh3wPhlahKYn2PSFhhG0."], ["name", "x91u126wvyeimgv52uh"], ["email", "8_vance.jakubowski@bradtke.example"], ["created_at", "2024-02-15 02:56:18.240382"], ["updated_at", "2024-02-15 02:56:18.240382"]]
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[35m (1.0ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles" WHERE "articles"."user_id" = $1[0m  [["user_id", 37]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (2.2ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"q1DC6fK7AOPiyV2y0wKV9A\\\":{\\\"token\\\":\\\"$2a$04$CATvxTHBL4Pm9R.ul67CIugKBTLm0SahYldNs.d3Wzs48War4YVqm\\\",\\\"expiry\\\":1709175378,\\\"updated_at\\\":\\\"2024-02-15T02:56:18Z\\\"}}\""], ["updated_at", "2024-02-15 02:56:18.247247"], ["id", 37]]
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/articles" for 127.0.0.1 at 2024-02-15 11:56:18 +0900
+Processing by Api::V1::ArticlesController#create as HTML
+  Parameters: {"article"=>{"title"=>"救急車", "body"=>"開閉窒息全日本うえる。"}}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "8_vance.jakubowski@bradtke.example"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.8ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "救急車"], ["body", "開閉窒息全日本うえる。"], ["user_id", 37], ["created_at", "2024-02-15 02:56:18.268281"], ["updated_at", "2024-02-15 02:56:18.268281"]]
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered Api::V1::ArticleSerializer with ActiveModelSerializers::Adapter::Attributes (0.33ms)
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 37], ["LIMIT", 1]]
+Completed 200 OK in 14ms (Views: 0.6ms | ActiveRecord: 5.9ms | Allocations: 3078)
+  [1m[35m (1.0ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles" WHERE "articles"."user_id" = $1[0m  [["user_id", 37]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.4ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "9_raymond@hand.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.3ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "9_raymond@hand.example"], ["encrypted_password", "$2a$12$VF9HldYtM1/bjmMUnMMMhegpuYUcY9Y6yFLHFRpmuSz8O23kGw32S"], ["name", "k85jpq5utu3nh"], ["email", "9_raymond@hand.example"], ["created_at", "2024-02-15 02:56:18.571783"], ["updated_at", "2024-02-15 02:56:18.571783"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.9ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"bp0-HTeMXnVh9bV-pF-pvA\\\":{\\\"token\\\":\\\"$2a$04$GCm4JCJw3MTinS57WdUqYOlyx6dcwXW67hrrDhLBc41ruGUc4HlqS\\\",\\\"expiry\\\":1709175378,\\\"updated_at\\\":\\\"2024-02-15T02:56:18Z\\\"}}\""], ["updated_at", "2024-02-15 02:56:18.575841"], ["id", 38]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/articles" for 127.0.0.1 at 2024-02-15 11:56:18 +0900
+Processing by Api::V1::ArticlesController#create as HTML
+  Parameters: {"title"=>"むぜい", "body"=>"おかね備えるおきゃくさんきょうしつ。"}
+  [1m[36mUser Load (1.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "9_raymond@hand.example"], ["LIMIT", 1]]
+Completed 400 Bad Request in 4ms (ActiveRecord: 1.7ms | Allocations: 636)
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.7ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "10_orval@medhurst.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.7ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "10_orval@medhurst.example"], ["encrypted_password", "$2a$12$MgSL3JDJ8tUrrsjA2eA5k.AZyCTIprizRj0YwmTzyi8Fz.CV2LjHu"], ["name", "ca"], ["email", "10_orval@medhurst.example"], ["created_at", "2024-02-15 02:56:18.883359"], ["updated_at", "2024-02-15 02:56:18.883359"]]
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.4ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "窒息"], ["body", "しずむ配慮なおさら抑制。"], ["user_id", 39], ["created_at", "2024-02-15 02:56:18.887327"], ["updated_at", "2024-02-15 02:56:18.887327"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mArticle Load (0.8ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  [1m[36mArticle Load (0.7ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.2ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"ykalAdrVLsi_ndZV18etPg\\\":{\\\"token\\\":\\\"$2a$04$Y6Ag3g9Awx.wuLYLdubRD.IDjTz8huOcmSqkOfQ2p7iU/mS6sKH2O\\\",\\\"expiry\\\":1709175378,\\\"updated_at\\\":\\\"2024-02-15T02:56:18Z\\\"}}\""], ["updated_at", "2024-02-15 02:56:18.896225"], ["id", 39]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started PATCH "/api/v1/articles/6" for 127.0.0.1 at 2024-02-15 11:56:18 +0900
+Processing by Api::V1::ArticlesController#update as HTML
+  Parameters: {"article"=>{"title"=>"妥協する", "body"=>"たいやく既に雑音見当たる。"}, "id"=>"6"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "10_orval@medhurst.example"], ["LIMIT", 1]]
+  [1m[36mArticle Load (0.8ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."user_id" = $1 AND "articles"."id" = $2 LIMIT $3[0m  [["user_id", 39], ["id", 6], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Update (1.0ms)[0m  [1m[33mUPDATE "articles" SET "title" = $1, "body" = $2, "updated_at" = $3 WHERE "articles"."id" = $4[0m  [["title", "妥協する"], ["body", "たいやく既に雑音見当たる。"], ["updated_at", "2024-02-15 02:56:18.910549"], ["id", 6]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered Api::V1::ArticleSerializer with ActiveModelSerializers::Adapter::Attributes (0.3ms)
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 39], ["LIMIT", 1]]
+Completed 200 OK in 10ms (Views: 0.7ms | ActiveRecord: 5.3ms | Allocations: 2028)
+  [1m[36mArticle Load (0.9ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  [1m[36mArticle Load (1.3ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.9ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "11_ethelyn_davis@rosenbaum.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.0ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "11_ethelyn_davis@rosenbaum.test"], ["encrypted_password", "$2a$12$80dK8wkri7BKZp4hALpbve1MFW8g631hcL9J6i/UybUkKOKi5v2sK"], ["name", "xmf"], ["email", "11_ethelyn_davis@rosenbaum.test"], ["created_at", "2024-02-15 02:56:19.210763"], ["updated_at", "2024-02-15 02:56:19.210763"]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.1ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "しゃくや"], ["body", "待合ぶっきょう芸者漂う。"], ["user_id", 40], ["created_at", "2024-02-15 02:56:19.213183"], ["updated_at", "2024-02-15 02:56:19.213183"]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "12_charline.abbott@sporer-strosin.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.1ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "12_charline.abbott@sporer-strosin.example"], ["encrypted_password", "$2a$12$1BVRIdPTORxrM0kYPuRS1enph0QQF3BYHOPfgj3TpVm7tMy.qmSTq"], ["name", "7z1bbhr4w1c5aekvdm7q23"], ["email", "12_charline.abbott@sporer-strosin.example"], ["created_at", "2024-02-15 02:56:19.504717"], ["updated_at", "2024-02-15 02:56:19.504717"]]
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.0ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"uJZsZ3YembZ1JNVxycSHYg\\\":{\\\"token\\\":\\\"$2a$04$bz6cnnAb7mMojaOgI/uB6uG6tkFPd4xBHkkPX2RVjQ.KJMbXc7uVq\\\",\\\"expiry\\\":1709175379,\\\"updated_at\\\":\\\"2024-02-15T02:56:19Z\\\"}}\""], ["updated_at", "2024-02-15 02:56:19.509115"], ["id", 41]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started PATCH "/api/v1/articles/7" for 127.0.0.1 at 2024-02-15 11:56:19 +0900
+Processing by Api::V1::ArticlesController#update as HTML
+  Parameters: {"article"=>{"title"=>"勇気", "body"=>"病床平安自宅交錯。"}, "id"=>"7"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "12_charline.abbott@sporer-strosin.example"], ["LIMIT", 1]]
+  [1m[36mArticle Load (1.1ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."user_id" = $1 AND "articles"."id" = $2 LIMIT $3[0m  [["user_id", 41], ["id", 7], ["LIMIT", 1]]
+Completed 404 Not Found in 5ms (ActiveRecord: 2.5ms | Allocations: 922)
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.5ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "13_pam@botsford-steuber.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.4ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "13_pam@botsford-steuber.example"], ["encrypted_password", "$2a$12$wyvy5Kv59or1rdjjbmG0deXDGTauyrpRxE4VvPPVyPavq/WiML4ue"], ["name", "mqa5ktrf58u"], ["email", "13_pam@botsford-steuber.example"], ["created_at", "2024-02-15 02:56:19.894283"], ["updated_at", "2024-02-15 02:56:19.894283"]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (0.3ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "ころす"], ["body", "せいしん羊毛地面喜劇。"], ["user_id", 42], ["created_at", "2024-02-15 02:56:19.896373"], ["updated_at", "2024-02-15 02:56:19.896373"]]
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[35m (0.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles" WHERE "articles"."user_id" = $1[0m  [["user_id", 42]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.3ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"1v5q9YgF0ACQsdrAdBNlCg\\\":{\\\"token\\\":\\\"$2a$04$YNDKX9PHGOOcmvkbf28UIew/k/aWk07M5GY3e324yhk6pc8G5xWG2\\\",\\\"expiry\\\":1709175379,\\\"updated_at\\\":\\\"2024-02-15T02:56:19Z\\\"}}\""], ["updated_at", "2024-02-15 02:56:19.899985"], ["id", 42]]
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started DELETE "/api/v1/articles/8" for 127.0.0.1 at 2024-02-15 11:56:19 +0900
+Processing by Api::V1::ArticlesController#destroy as HTML
+  Parameters: {"id"=>"8"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "13_pam@botsford-steuber.example"], ["LIMIT", 1]]
+  [1m[36mArticle Load (0.3ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."user_id" = $1 AND "articles"."id" = $2 LIMIT $3[0m  [["user_id", 42], ["id", 8], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mComment Load (0.4ms)[0m  [1m[34mSELECT "comments".* FROM "comments" WHERE "comments"."article_id" = $1[0m  [["article_id", 8]]
+  [1m[36mArticleLike Load (0.3ms)[0m  [1m[34mSELECT "article_likes".* FROM "article_likes" WHERE "article_likes"."article_id" = $1[0m  [["article_id", 8]]
+  [1m[36mArticle Destroy (0.4ms)[0m  [1m[31mDELETE FROM "articles" WHERE "articles"."id" = $1[0m  [["id", 8]]
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+No template found for Api::V1::ArticlesController#destroy, rendering head :no_content
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 42], ["LIMIT", 1]]
+Completed 204 No Content in 14ms (ActiveRecord: 4.2ms | Allocations: 6554)
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles" WHERE "articles"."user_id" = $1[0m  [["user_id", 42]]
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "14_kiersten.heathcote@rowe-bartell.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.3ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "14_kiersten.heathcote@rowe-bartell.example"], ["encrypted_password", "$2a$12$6/W5cHPvqaF8ezmVU.TMJe4sKJ6IG86FsHI0uwWAZ3bUbdtK/BjK."], ["name", "cecvicawx0dqrhtr7m6nv"], ["email", "14_kiersten.heathcote@rowe-bartell.example"], ["created_at", "2024-02-15 02:56:20.214494"], ["updated_at", "2024-02-15 02:56:20.214494"]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (2.2ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "平安"], ["body", "のきたいりく色盲あしくび。"], ["user_id", 43], ["created_at", "2024-02-15 02:56:20.217563"], ["updated_at", "2024-02-15 02:56:20.217563"]]
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[35m (1.0ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles"[0m
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.0ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "15_regena.reichel@mosciski-roob.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (2.1ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "15_regena.reichel@mosciski-roob.example"], ["encrypted_password", "$2a$12$N1CA6XWinb6kzm2E0BHVeOG4oX5JVgdC7MQuKgFrrvOh1oAcQen1q"], ["name", "o6i22a78pa534lnm"], ["email", "15_regena.reichel@mosciski-roob.example"], ["created_at", "2024-02-15 02:56:20.516814"], ["updated_at", "2024-02-15 02:56:20.516814"]]
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.6ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"0jFFu8bhM19Trq39aHpjiw\\\":{\\\"token\\\":\\\"$2a$04$vSHgOpZlIDz5Av.kH376iufGcToPnwgdoG5wvtG30zwENGGbiuSNG\\\",\\\"expiry\\\":1709175380,\\\"updated_at\\\":\\\"2024-02-15T02:56:20Z\\\"}}\""], ["updated_at", "2024-02-15 02:56:20.522199"], ["id", 44]]
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started DELETE "/api/v1/articles/9" for 127.0.0.1 at 2024-02-15 11:56:20 +0900
+Processing by Api::V1::ArticlesController#destroy as HTML
+  Parameters: {"id"=>"9"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "15_regena.reichel@mosciski-roob.example"], ["LIMIT", 1]]
+  [1m[36mArticle Load (1.6ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."user_id" = $1 AND "articles"."id" = $2 LIMIT $3[0m  [["user_id", 44], ["id", 9], ["LIMIT", 1]]
+Completed 404 Not Found in 15ms (ActiveRecord: 2.8ms | Allocations: 924)
+  [1m[35m (1.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles"[0m
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (3.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 11:56:20 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"rcozun6tr97j2i8laim", "email"=>"16_tracy.cartwright@padberg.test", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.5ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.7ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "16_tracy.cartwright@padberg.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.2ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "16_tracy.cartwright@padberg.test"], ["encrypted_password", "$2a$12$mRWf8LHWfU8mCdQHDipR0O5.nxGIWPUtw7f2M9YXlU.g.zwmd7vFe"], ["name", "rcozun6tr97j2i8laim"], ["email", "16_tracy.cartwright@padberg.test"], ["created_at", "2024-02-15 02:56:21.006223"], ["updated_at", "2024-02-15 02:56:21.006223"]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (2.6ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"XcEEKtD1ebFCh5a5bJZbfg\\\":{\\\"token\\\":\\\"$2a$04$NWZDoSi3h7dYbRszHNep9OKSdjAfSxmAOOo0yz7y.aRW8CkWt33i2\\\",\\\"expiry\\\":1709175381}}\""], ["updated_at", "2024-02-15 02:56:21.010302"], ["id", 45]]
+  [1m[36mTRANSACTION (2.4ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 45], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.09ms)
+Completed 200 OK in 338ms (Views: 1.4ms | ActiveRecord: 12.2ms | Allocations: 3753)
+  [1m[35m (1.0ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 11:56:21 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"6g853g", "email"=>"17_jacalyn.reynolds@mckenzie.test", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.8ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "17_jacalyn.reynolds@mckenzie.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.1ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "17_jacalyn.reynolds@mckenzie.test"], ["encrypted_password", "$2a$12$xNK//6lwdT7LHz6OmhRvx.L2V2W5Or.7gNShdN91OFNqAj5H9LBEq"], ["name", "6g853g"], ["email", "17_jacalyn.reynolds@mckenzie.test"], ["created_at", "2024-02-15 02:56:21.344181"], ["updated_at", "2024-02-15 02:56:21.344181"]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.4ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"Y3akIiQDB-uyK6zX5Quvog\\\":{\\\"token\\\":\\\"$2a$04$F8P3Nw8Pskx4FRO4V4QRa.0rbAd/j7Mob92.F6sfZBLR4oMLwGxTy\\\",\\\"expiry\\\":1709175381}}\""], ["updated_at", "2024-02-15 02:56:21.348725"], ["id", 46]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 46], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.06ms)
+Completed 200 OK in 313ms (Views: 0.4ms | ActiveRecord: 6.9ms | Allocations: 2843)
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.6ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 11:56:21 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>nil, "email"=>"18_diego@kertzmann-purdy.example", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "18_diego@kertzmann-purdy.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK TO SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.11ms)
+Completed 422 Unprocessable Entity in 295ms (Views: 0.3ms | ActiveRecord: 2.7ms | Allocations: 2340)
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (1.0ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 11:56:21 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"q8shl2o2pzkuxp4i8kd537gq72", "email"=>nil, "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.0ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."email" IS NULL AND "users"."provider" = $1 LIMIT $2[0m  [["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK TO SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.09ms)
+Completed 422 Unprocessable Entity in 305ms (Views: 0.3ms | ActiveRecord: 2.6ms | Allocations: 2121)
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (2.3ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 11:56:21 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"o5gvql", "email"=>"19_kelley.herzog@treutel.test", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "19_kelley.herzog@treutel.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[31mROLLBACK TO SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.09ms)
+Completed 422 Unprocessable Entity in 4ms (Views: 0.3ms | ActiveRecord: 1.6ms | Allocations: 2104)
+  [1m[35m (0.9ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.0ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "20_drucilla@oconnell-smitham.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.9ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "20_drucilla@oconnell-smitham.test"], ["encrypted_password", "$2a$12$2riMdKz0t5/5529u5GffSuHOvuVEoGK744SsgAB8LgWLHCDG1aP26"], ["name", "lwy"], ["email", "20_drucilla@oconnell-smitham.test"], ["created_at", "2024-02-15 02:56:22.293468"], ["updated_at", "2024-02-15 02:56:22.293468"]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/auth/sign_in" for 127.0.0.1 at 2024-02-15 11:56:22 +0900
+Processing by DeviseTokenAuth::SessionsController#create as HTML
+  Parameters: {"name"=>"atydb3vaww0968430i", "email"=>"20_drucilla@oconnell-smitham.test", "password"=>"[FILTERED]"}
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."email" = $1 AND "users"."provider" = $2 LIMIT $3[0m  [["email", "20_drucilla@oconnell-smitham.test"], ["provider", "email"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Load (1.8ms)[0m  [1m[37mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2 FOR UPDATE[0m  [["id", 47], ["LIMIT", 1]]
+  [1m[36mUser Update (1.7ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"PZ8y9QY73PMoeSiqmQA9Xw\\\":{\\\"token\\\":\\\"$2a$04$U8RR/h5oMded2wxkcoHYzeAwo3dQnDE21P3WkdJBzzERJGkbDShsS\\\",\\\"expiry\\\":1709175382}}\""], ["updated_at", "2024-02-15 02:56:22.600365"], ["id", 47]]
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.05ms)
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 47], ["LIMIT", 1]]
+Completed 200 OK in 302ms (Views: 0.4ms | ActiveRecord: 7.7ms | Allocations: 3303)
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.7ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "21_matthew.ward@okon.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.7ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "21_matthew.ward@okon.example"], ["encrypted_password", "$2a$12$apc1P6803uk6VqdV.QSWJeSYHLKJsdRgqg61CQbUkJ0BBqfRLS3xm"], ["name", "4o9xarpsmtz"], ["email", "21_matthew.ward@okon.example"], ["created_at", "2024-02-15 02:56:22.910219"], ["updated_at", "2024-02-15 02:56:22.910219"]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/auth/sign_in" for 127.0.0.1 at 2024-02-15 11:56:22 +0900
+Processing by DeviseTokenAuth::SessionsController#create as HTML
+  Parameters: {"name"=>"vlx3j79j64j0bgynqh9gaaze5wuav6", "email"=>"foo", "password"=>"[FILTERED]"}
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."email" = $1 AND "users"."provider" = $2 LIMIT $3[0m  [["email", "foo"], ["provider", "email"], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.05ms)
+Completed 401 Unauthorized in 2ms (Views: 0.2ms | ActiveRecord: 1.0ms | Allocations: 667)
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "22_junior.sporer@rice.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.0ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "22_junior.sporer@rice.example"], ["encrypted_password", "$2a$12$trZCP6nNgObofE1kz/wOvOAi4qd9b1McXPMVsl5qHN.nBRhrcQ0Vi"], ["name", "c8jw1s"], ["email", "22_junior.sporer@rice.example"], ["created_at", "2024-02-15 02:56:23.212797"], ["updated_at", "2024-02-15 02:56:23.212797"]]
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/auth/sign_in" for 127.0.0.1 at 2024-02-15 11:56:23 +0900
+Processing by DeviseTokenAuth::SessionsController#create as HTML
+  Parameters: {"name"=>"c2hadngevo6l03", "email"=>"22_junior.sporer@rice.example", "password"=>"[FILTERED]"}
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."email" = $1 AND "users"."provider" = $2 LIMIT $3[0m  [["email", "22_junior.sporer@rice.example"], ["provider", "email"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.06ms)
+Completed 401 Unauthorized in 287ms (Views: 0.3ms | ActiveRecord: 1.4ms | Allocations: 850)
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "23_margy@larkin.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.4ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "23_margy@larkin.test"], ["encrypted_password", "$2a$12$3X4RMbO7IQChH47rVUnloeJxWy9nZ.JWUKcAjMLdboaR3Ua6GIKuW"], ["name", "fwqlyat360yhcfo9"], ["email", "23_margy@larkin.test"], ["created_at", "2024-02-15 02:56:23.800479"], ["updated_at", "2024-02-15 02:56:23.800479"]]
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.2ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"i9IZl4nJQpL5_6l11RGLEA\\\":{\\\"token\\\":\\\"$2a$04$qum1O01dVIzvp1cjLCG7gOGUtZONIxxCnQtRqk3hWWl8ju2w77Z12\\\",\\\"expiry\\\":1709175383,\\\"updated_at\\\":\\\"2024-02-15T02:56:23Z\\\"}}\""], ["updated_at", "2024-02-15 02:56:23.805167"], ["id", 50]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 50], ["LIMIT", 1]]
+Started DELETE "/api/v1/auth/sign_out" for 127.0.0.1 at 2024-02-15 11:56:23 +0900
+Processing by DeviseTokenAuth::SessionsController#destroy as HTML
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "23_margy@larkin.test"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.8ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", nil], ["updated_at", "2024-02-15 02:56:23.818488"], ["id", 50]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.03ms)
+Completed 200 OK in 8ms (Views: 0.2ms | ActiveRecord: 4.6ms | Allocations: 1297)
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 50], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mBEGIN[0m
+Started DELETE "/api/v1/auth/sign_out" for 127.0.0.1 at 2024-02-15 11:56:23 +0900
+Processing by DeviseTokenAuth::SessionsController#destroy as HTML
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.05ms)
+Completed 404 Not Found in 0ms (Views: 0.2ms | ActiveRecord: 0.0ms | Allocations: 368)
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[35m (1.4ms)[0m  [1m[34mSELECT "ar_internal_metadata"."value" FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1[0m  [["key", "schema_sha1"]]
+  [1m[35m (1.1ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 12:03:55 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"cf", "email"=>"1_jared@heidenreich.example", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.5ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "1_jared@heidenreich.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (3.4ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "1_jared@heidenreich.example"], ["encrypted_password", "$2a$12$W5EYTYRuwYEkoHAC83XRpepOtRQM6jGrry4FlinHemTJMw03mzthG"], ["name", "cf"], ["email", "1_jared@heidenreich.example"], ["created_at", "2024-02-15 03:03:55.440997"], ["updated_at", "2024-02-15 03:03:55.440997"]]
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.5ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (2.0ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"33Hd3cCt_MBWEd0l5ng07w\\\":{\\\"token\\\":\\\"$2a$04$kyELPXTMlFxNIYxuIxIHNOUECfpnIIV5qQvLqZz7SbIuRPiPzn3fC\\\",\\\"expiry\\\":1709175835}}\""], ["updated_at", "2024-02-15 03:03:55.448420"], ["id", 51]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 51], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.12ms)
+Completed 200 OK in 333ms (Views: 1.5ms | ActiveRecord: 24.4ms | Allocations: 16365)
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[31mROLLBACK[0m
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT "ar_internal_metadata"."value" FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1[0m  [["key", "schema_sha1"]]
+  [1m[35m (0.9ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (3.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "2_curtis_ritchie@friesen.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (1.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."email" IS NULL AND "users"."provider" = $1 LIMIT $2[0m  [["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (3.0ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."email" IS NULL AND "users"."provider" = $1 LIMIT $2[0m  [["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "3_noah.champlin@borer-hyatt.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.5ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.4ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "4_sandy@fritsch.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (2.0ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "4_sandy@fritsch.test"], ["encrypted_password", "$2a$12$ZWbby4WfoTSSW9vXkzIYs.8ZTBZq2ir8bHszUswg3y0V3jB3bMi3O"], ["name", "xj51lvvk63bc5fx"], ["email", "4_sandy@fritsch.test"], ["created_at", "2024-02-15 03:09:09.263008"], ["updated_at", "2024-02-15 03:09:09.263008"]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.8ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "すんか"], ["body", "碁見当たる米兵面。"], ["user_id", 52], ["created_at", "2024-02-15 03:09:09.267040"], ["updated_at", "2024-02-14 03:09:08.968808"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "5_troy_considine@cormier.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.9ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "5_troy_considine@cormier.example"], ["encrypted_password", "$2a$12$b1/mupxwejLsR1dEM8REIujrb1G7LflGun6frghT16hQT19xHJYX6"], ["name", "sygg0nxjopwkbxxzdnui0lwt578p0"], ["email", "5_troy_considine@cormier.example"], ["created_at", "2024-02-15 03:09:09.566491"], ["updated_at", "2024-02-15 03:09:09.566491"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.0ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "かくじっけん"], ["body", "巡回ちあんかんぜん近視。"], ["user_id", 53], ["created_at", "2024-02-15 03:09:09.568675"], ["updated_at", "2024-02-13 03:09:09.270443"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.0ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "6_weston@schimmel.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.3ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "6_weston@schimmel.example"], ["encrypted_password", "$2a$12$A0EAR2mhcqzU3ST.KBrqdeBUXAedttG.JUAL24v3QslI9DYO2Tr3."], ["name", "3wiuyxozvbflj"], ["email", "6_weston@schimmel.example"], ["created_at", "2024-02-15 03:09:09.858668"], ["updated_at", "2024-02-15 03:09:09.858668"]]
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.0ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "当て字"], ["body", "シアトルし渦巻きおりめ犠牲。"], ["user_id", 54], ["created_at", "2024-02-15 03:09:09.861568"], ["updated_at", "2024-02-15 03:09:09.861568"]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/articles" for 127.0.0.1 at 2024-02-15 12:09:09 +0900
+Processing by Api::V1::ArticlesController#index as HTML
+  [1m[36mArticle Load (1.0ms)[0m  [1m[34mSELECT "articles".* FROM "articles" ORDER BY "articles"."updated_at" DESC[0m
+[active_model_serializers]   [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 54], ["LIMIT", 1]]
+[active_model_serializers]   [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 52], ["LIMIT", 1]]
+[active_model_serializers]   [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 53], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::Attributes (7.27ms)
+Completed 200 OK in 16ms (Views: 8.1ms | ActiveRecord: 3.1ms | Allocations: 6835)
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "7_tiny_beer@welch-luettgen.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.1ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "7_tiny_beer@welch-luettgen.example"], ["encrypted_password", "$2a$12$JmRQ0j1l/jOymPWCCTrkWOjl4pm9/cwRqk0.wWSCHkst2GXf/ZgHq"], ["name", "gxcg4lgz6q9s4ta4k9fzjrv1w26qv"], ["email", "7_tiny_beer@welch-luettgen.example"], ["created_at", "2024-02-15 03:09:10.197506"], ["updated_at", "2024-02-15 03:09:10.197506"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.1ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "米兵"], ["body", "ぼきん雇用へいがい俵。"], ["user_id", 55], ["created_at", "2024-02-15 03:09:10.199951"], ["updated_at", "2024-02-15 03:09:10.199951"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started GET "/api/v1/articles/13" for 127.0.0.1 at 2024-02-15 12:09:10 +0900
+Processing by Api::V1::ArticlesController#show as HTML
+  Parameters: {"id"=>"13"}
+  [1m[36mArticle Load (1.0ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 13], ["LIMIT", 1]]
+[active_model_serializers]   [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 55], ["LIMIT", 1]]
+[active_model_serializers] Rendered Api::V1::ArticleSerializer with ActiveModelSerializers::Adapter::Attributes (2.1ms)
+Completed 200 OK in 7ms (Views: 1.3ms | ActiveRecord: 2.2ms | Allocations: 1679)
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mBEGIN[0m
+Started GET "/api/v1/articles/10000" for 127.0.0.1 at 2024-02-15 12:09:10 +0900
+Processing by Api::V1::ArticlesController#show as HTML
+  Parameters: {"id"=>"10000"}
+  [1m[36mArticle Load (1.0ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 10000], ["LIMIT", 1]]
+Completed 404 Not Found in 2ms (ActiveRecord: 1.0ms | Allocations: 448)
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.4ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "8_antwan.mann@bashirian.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (2.2ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "8_antwan.mann@bashirian.test"], ["encrypted_password", "$2a$12$E7HAcafI9RnCFwvAEJ0s5e6sc9zpLfoAWUV.uYcoORiuSiAYoT7RK"], ["name", "f2dytga2"], ["email", "8_antwan.mann@bashirian.test"], ["created_at", "2024-02-15 03:09:10.525383"], ["updated_at", "2024-02-15 03:09:10.525383"]]
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[35m (1.5ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles" WHERE "articles"."user_id" = $1[0m  [["user_id", 56]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.1ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"LDkGOvfCoFPvSa-q1sdDBQ\\\":{\\\"token\\\":\\\"$2a$04$71zZBFTfVEQZHrSMk0WfAuV8iSAA8KbRJjMYO4irCU.MH.Bn5rcMm\\\",\\\"expiry\\\":1709176150,\\\"updated_at\\\":\\\"2024-02-15T03:09:10Z\\\"}}\""], ["updated_at", "2024-02-15 03:09:10.533312"], ["id", 56]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/articles" for 127.0.0.1 at 2024-02-15 12:09:10 +0900
+Processing by Api::V1::ArticlesController#create as HTML
+  Parameters: {"article"=>{"title"=>"しずむ", "body"=>"大尉人口右利ききもち。"}}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "8_antwan.mann@bashirian.test"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.1ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "しずむ"], ["body", "大尉人口右利ききもち。"], ["user_id", 56], ["created_at", "2024-02-15 03:09:10.551983"], ["updated_at", "2024-02-15 03:09:10.551983"]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered Api::V1::ArticleSerializer with ActiveModelSerializers::Adapter::Attributes (0.34ms)
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 56], ["LIMIT", 1]]
+Completed 200 OK in 12ms (Views: 0.6ms | ActiveRecord: 4.5ms | Allocations: 3076)
+  [1m[35m (1.9ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles" WHERE "articles"."user_id" = $1[0m  [["user_id", 56]]
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.0ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "9_zack.ullrich@klein.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.1ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "9_zack.ullrich@klein.test"], ["encrypted_password", "$2a$12$QboJMCrC7Yas5O6NQe5Z9e/.sZ.CvZe3lQ0Q9EhQlBb4hBnU4B5Cm"], ["name", "adxx2qeg6"], ["email", "9_zack.ullrich@klein.test"], ["created_at", "2024-02-15 03:09:10.851793"], ["updated_at", "2024-02-15 03:09:10.851793"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.6ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"rC_5b5u9qcf6kMZk_uX-SQ\\\":{\\\"token\\\":\\\"$2a$04$y3atQXpQ.aqobmNDJSpbZOuCEY1.mBBC3RY7.Cq5xFmFophx0Ku/a\\\",\\\"expiry\\\":1709176150,\\\"updated_at\\\":\\\"2024-02-15T03:09:10Z\\\"}}\""], ["updated_at", "2024-02-15 03:09:10.855703"], ["id", 57]]
+  [1m[36mTRANSACTION (1.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/articles" for 127.0.0.1 at 2024-02-15 12:09:10 +0900
+Processing by Api::V1::ArticlesController#create as HTML
+  Parameters: {"title"=>"液体", "body"=>"輸出封筒かんぜん泳ぐ。"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "9_zack.ullrich@klein.test"], ["LIMIT", 1]]
+Completed 400 Bad Request in 3ms (ActiveRecord: 1.2ms | Allocations: 636)
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "10_carlos.weissnat@volkman.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.2ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "10_carlos.weissnat@volkman.test"], ["encrypted_password", "$2a$12$duspcFab6SYh63CtdhuPA.QqQdc87Yc7iLQxI5D9hC9oukAu4NHuu"], ["name", "o463j"], ["email", "10_carlos.weissnat@volkman.test"], ["created_at", "2024-02-15 03:09:11.161538"], ["updated_at", "2024-02-15 03:09:11.161538"]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.0ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "ちょさくけん"], ["body", "飽くまでもよぼう自立じぞう。"], ["user_id", 58], ["created_at", "2024-02-15 03:09:11.164284"], ["updated_at", "2024-02-15 03:09:11.164284"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mArticle Load (0.8ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  [1m[36mArticle Load (0.7ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.6ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"UghwCPSv-47K_3ozLVs82Q\\\":{\\\"token\\\":\\\"$2a$04$n.z6O7yW3/Tor6nBczgPZuNVMjRpvCt3Z9JimK60DbYNjNLQG/YAq\\\",\\\"expiry\\\":1709176151,\\\"updated_at\\\":\\\"2024-02-15T03:09:11Z\\\"}}\""], ["updated_at", "2024-02-15 03:09:11.173085"], ["id", 58]]
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started PATCH "/api/v1/articles/15" for 127.0.0.1 at 2024-02-15 12:09:11 +0900
+Processing by Api::V1::ArticlesController#update as HTML
+  Parameters: {"article"=>{"title"=>"自立", "body"=>"ハチのす部首哀れむあつかい。"}, "id"=>"15"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "10_carlos.weissnat@volkman.test"], ["LIMIT", 1]]
+  [1m[36mArticle Load (1.1ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."user_id" = $1 AND "articles"."id" = $2 LIMIT $3[0m  [["user_id", 58], ["id", 15], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Update (1.8ms)[0m  [1m[33mUPDATE "articles" SET "title" = $1, "body" = $2, "updated_at" = $3 WHERE "articles"."id" = $4[0m  [["title", "自立"], ["body", "ハチのす部首哀れむあつかい。"], ["updated_at", "2024-02-15 03:09:11.188903"], ["id", 15]]
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered Api::V1::ArticleSerializer with ActiveModelSerializers::Adapter::Attributes (0.29ms)
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 58], ["LIMIT", 1]]
+Completed 200 OK in 12ms (Views: 0.5ms | ActiveRecord: 7.0ms | Allocations: 2028)
+  [1m[36mArticle Load (0.7ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  [1m[36mArticle Load (0.6ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.4ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "11_tameka.larson@kertzmann-carter.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.5ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "11_tameka.larson@kertzmann-carter.test"], ["encrypted_password", "$2a$12$KbX/QYsZ1weZR7VC7MJudOAUHl09Cbo9G.t2kC5boUBY6jPkE3lB6"], ["name", "kb"], ["email", "11_tameka.larson@kertzmann-carter.test"], ["created_at", "2024-02-15 03:09:11.496007"], ["updated_at", "2024-02-15 03:09:11.496007"]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (0.3ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "問題"], ["body", "山葵悲しみ宜しくかくじっけん。"], ["user_id", 59], ["created_at", "2024-02-15 03:09:11.497835"], ["updated_at", "2024-02-15 03:09:11.497835"]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (2.5ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "12_issac_dooley@schmidt.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.0ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "12_issac_dooley@schmidt.example"], ["encrypted_password", "$2a$12$jTIEmlTQUxxxLdEJCAFVse8af2Ve3SOu2VdDJpJajfVHSA7YQIdPm"], ["name", "vb0vresfbvsvtqddmn0too68a"], ["email", "12_issac_dooley@schmidt.example"], ["created_at", "2024-02-15 03:09:11.796619"], ["updated_at", "2024-02-15 03:09:11.796619"]]
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.9ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"9WH35IgFp4QcC_ygM8t8Ww\\\":{\\\"token\\\":\\\"$2a$04$MsL8k2b4A2E1hQy0kPnuBeAuk4p/HgI/i7pldRCbm.sDhcWRIt9Qa\\\",\\\"expiry\\\":1709176151,\\\"updated_at\\\":\\\"2024-02-15T03:09:11Z\\\"}}\""], ["updated_at", "2024-02-15 03:09:11.800103"], ["id", 60]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started PATCH "/api/v1/articles/16" for 127.0.0.1 at 2024-02-15 12:09:11 +0900
+Processing by Api::V1::ArticlesController#update as HTML
+  Parameters: {"article"=>{"title"=>"下着", "body"=>"せっぷくかっこうぼうず遺失。"}, "id"=>"16"}
+  [1m[36mUser Load (1.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "12_issac_dooley@schmidt.example"], ["LIMIT", 1]]
+  [1m[36mArticle Load (1.1ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."user_id" = $1 AND "articles"."id" = $2 LIMIT $3[0m  [["user_id", 60], ["id", 16], ["LIMIT", 1]]
+Completed 404 Not Found in 5ms (ActiveRecord: 2.7ms | Allocations: 923)
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "13_moshe@rippin.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.6ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "13_moshe@rippin.example"], ["encrypted_password", "$2a$12$RFEsOeMTQTLFyS/kdUBGGuyokavVPDptDIuZ3h9EktVNopetjy88O"], ["name", "g3"], ["email", "13_moshe@rippin.example"], ["created_at", "2024-02-15 03:09:12.105712"], ["updated_at", "2024-02-15 03:09:12.105712"]]
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (1.4ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "馬鹿馬鹿しい"], ["body", "閉じるけいけんしゃせいかんあびる。"], ["user_id", 61], ["created_at", "2024-02-15 03:09:12.109534"], ["updated_at", "2024-02-15 03:09:12.109534"]]
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[35m (1.0ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles" WHERE "articles"."user_id" = $1[0m  [["user_id", 61]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.9ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"tPJ6cgN3m2n1adeibBKspQ\\\":{\\\"token\\\":\\\"$2a$04$T8xbLvlEIICZakjNLbL90OgxbDRCfpSCUJr1LVz3pgYPC9AUoVLem\\\",\\\"expiry\\\":1709176152,\\\"updated_at\\\":\\\"2024-02-15T03:09:12Z\\\"}}\""], ["updated_at", "2024-02-15 03:09:12.116510"], ["id", 61]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started DELETE "/api/v1/articles/17" for 127.0.0.1 at 2024-02-15 12:09:12 +0900
+Processing by Api::V1::ArticlesController#destroy as HTML
+  Parameters: {"id"=>"17"}
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "13_moshe@rippin.example"], ["LIMIT", 1]]
+  [1m[36mArticle Load (1.1ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."user_id" = $1 AND "articles"."id" = $2 LIMIT $3[0m  [["user_id", 61], ["id", 17], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mComment Load (1.2ms)[0m  [1m[34mSELECT "comments".* FROM "comments" WHERE "comments"."article_id" = $1[0m  [["article_id", 17]]
+  [1m[36mArticleLike Load (1.9ms)[0m  [1m[34mSELECT "article_likes".* FROM "article_likes" WHERE "article_likes"."article_id" = $1[0m  [["article_id", 17]]
+  [1m[36mArticle Destroy (1.6ms)[0m  [1m[31mDELETE FROM "articles" WHERE "articles"."id" = $1[0m  [["id", 17]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+No template found for Api::V1::ArticlesController#destroy, rendering head :no_content
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 61], ["LIMIT", 1]]
+Completed 204 No Content in 26ms (ActiveRecord: 15.8ms | Allocations: 6552)
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles" WHERE "articles"."user_id" = $1[0m  [["user_id", 61]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.4ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "14_carmen.hickle@altenwerth.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.7ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "14_carmen.hickle@altenwerth.test"], ["encrypted_password", "$2a$12$3axcOXgRxoKlup.qeXV.I.8.byzMBN3fV85MaJNQHd0f6gCmGFdE2"], ["name", "o372bo0d03g"], ["email", "14_carmen.hickle@altenwerth.test"], ["created_at", "2024-02-15 03:09:12.445618"], ["updated_at", "2024-02-15 03:09:12.445618"]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mArticle Create (0.9ms)[0m  [1m[32mINSERT INTO "articles" ("title", "body", "user_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"[0m  [["title", "きいろ"], ["body", "仕事いう特殊憂い。"], ["user_id", 62], ["created_at", "2024-02-15 03:09:12.448970"], ["updated_at", "2024-02-15 03:09:12.448970"]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles"[0m
+  [1m[36mTRANSACTION (1.4ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.0ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "15_val@botsford-gusikowski.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.9ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "15_val@botsford-gusikowski.example"], ["encrypted_password", "$2a$12$YzMEvnJNPyWU8AZoqv6r8OxX/e7YdduBQPqyrWXtXllpaw9uD6M8q"], ["name", "h64p5ibcqheh461s4j"], ["email", "15_val@botsford-gusikowski.example"], ["created_at", "2024-02-15 03:09:12.779939"], ["updated_at", "2024-02-15 03:09:12.779939"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.9ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"UlEPt8pf9WjcVF_kMzRt_g\\\":{\\\"token\\\":\\\"$2a$04$RMiCV3XABvVvXAjtxO1RaeZ9M2f1RJFSeRgylwhijxwpsC0rkRMHS\\\",\\\"expiry\\\":1709176152,\\\"updated_at\\\":\\\"2024-02-15T03:09:12Z\\\"}}\""], ["updated_at", "2024-02-15 03:09:12.783633"], ["id", 63]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started DELETE "/api/v1/articles/18" for 127.0.0.1 at 2024-02-15 12:09:12 +0900
+Processing by Api::V1::ArticlesController#destroy as HTML
+  Parameters: {"id"=>"18"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "15_val@botsford-gusikowski.example"], ["LIMIT", 1]]
+  [1m[36mArticle Load (1.1ms)[0m  [1m[34mSELECT "articles".* FROM "articles" WHERE "articles"."user_id" = $1 AND "articles"."id" = $2 LIMIT $3[0m  [["user_id", 63], ["id", 18], ["LIMIT", 1]]
+Completed 404 Not Found in 5ms (ActiveRecord: 2.6ms | Allocations: 924)
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "articles"[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.7ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 12:09:12 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"ukpv1o5oypr53rx5f8599m16hmz0", "email"=>"16_arlie@macejkovic-ernser.test", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.2ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "16_arlie@macejkovic-ernser.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.9ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "16_arlie@macejkovic-ernser.test"], ["encrypted_password", "$2a$12$7Oldf4dUwNQsjSEFXecxlenTILffCDID/Wl.4X06LF/27j9W0A3JO"], ["name", "ukpv1o5oypr53rx5f8599m16hmz0"], ["email", "16_arlie@macejkovic-ernser.test"], ["created_at", "2024-02-15 03:09:13.101967"], ["updated_at", "2024-02-15 03:09:13.101967"]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.8ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.1ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"9Tm87YFXmeGp75oRPvKxUg\\\":{\\\"token\\\":\\\"$2a$04$LiUOjhiD5dbojnSpx8/GweweyCSviWKFvu6VYrmGP3URDg9iX2ZRi\\\",\\\"expiry\\\":1709176153}}\""], ["updated_at", "2024-02-15 03:09:13.105673"], ["id", 64]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 64], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.07ms)
+Completed 200 OK in 299ms (Views: 1.2ms | ActiveRecord: 8.2ms | Allocations: 3753)
+  [1m[35m (0.9ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" ORDER BY "users"."id" DESC LIMIT $1[0m  [["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mBEGIN[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 12:09:13 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"y897uaxqonvi3hrjiyf81hxiyzjna", "email"=>"17_andreas@purdy-deckow.test", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.9ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "17_andreas@purdy-deckow.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.8ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "17_andreas@purdy-deckow.test"], ["encrypted_password", "$2a$12$TSmDwIHm5qHwPelxbODlK.k8O7lfem2KDxAPurRoyvKhpedA34I4q"], ["name", "y897uaxqonvi3hrjiyf81hxiyzjna"], ["email", "17_andreas@purdy-deckow.test"], ["created_at", "2024-02-15 03:09:13.412787"], ["updated_at", "2024-02-15 03:09:13.412787"]]
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (0.9ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"kwPJ4-QYOKR3OORC1g5fhA\\\":{\\\"token\\\":\\\"$2a$04$qAOvtK1MnfB0BoxAy1bfy.mwxNy4TUcokkSgKBK3Rrhw2bFFrlIta\\\",\\\"expiry\\\":1709176153}}\""], ["updated_at", "2024-02-15 03:09:13.416211"], ["id", 65]]
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 65], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.09ms)
+Completed 200 OK in 295ms (Views: 0.3ms | ActiveRecord: 5.7ms | Allocations: 2844)
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (1.2ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 12:09:13 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>nil, "email"=>"18_oliver_dooley@fay-buckridge.test", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "18_oliver_dooley@fay-buckridge.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[31mROLLBACK TO SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.09ms)
+Completed 422 Unprocessable Entity in 290ms (Views: 0.3ms | ActiveRecord: 3.0ms | Allocations: 2340)
+  [1m[35m (1.9ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.9ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 12:09:13 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"3vy6b", "email"=>nil, "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.9ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE "users"."email" IS NULL AND "users"."provider" = $1 LIMIT $2[0m  [["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK TO SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.08ms)
+Completed 422 Unprocessable Entity in 298ms (Views: 0.3ms | ActiveRecord: 2.6ms | Allocations: 2121)
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (1.1ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+Started POST "/api/v1/auth" for 127.0.0.1 at 2024-02-15 12:09:14 +0900
+Processing by Api::V1::Auth::RegistrationsController#create as HTML
+  Parameters: {"name"=>"z23zbslrqe9", "email"=>"19_tianna@pouros.example", "password"=>"[FILTERED]"}
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.3ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "19_tianna@pouros.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[31mROLLBACK TO SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.09ms)
+Completed 422 Unprocessable Entity in 6ms (Views: 0.3ms | ActiveRecord: 3.4ms | Allocations: 2104)
+  [1m[35m (1.8ms)[0m  [1m[34mSELECT COUNT(*) FROM "users"[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.1ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "20_bo_leannon@haag.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.3ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "20_bo_leannon@haag.example"], ["encrypted_password", "$2a$12$NOoTrmJpkDW/aY5AF8X4/Ogw0prH8BROnOBfefhf6EvLgz1TbbiaS"], ["name", "u1wmgu"], ["email", "20_bo_leannon@haag.example"], ["created_at", "2024-02-15 03:09:14.484955"], ["updated_at", "2024-02-15 03:09:14.484955"]]
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/auth/sign_in" for 127.0.0.1 at 2024-02-15 12:09:14 +0900
+Processing by DeviseTokenAuth::SessionsController#create as HTML
+  Parameters: {"name"=>"rd2m", "email"=>"20_bo_leannon@haag.example", "password"=>"[FILTERED]"}
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."email" = $1 AND "users"."provider" = $2 LIMIT $3[0m  [["email", "20_bo_leannon@haag.example"], ["provider", "email"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Load (1.8ms)[0m  [1m[37mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2 FOR UPDATE[0m  [["id", 66], ["LIMIT", 1]]
+  [1m[36mUser Update (1.5ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"BSANj0KxW2V1HmdnX_Q39w\\\":{\\\"token\\\":\\\"$2a$04$Q4Gf5ZfClCWzofDRj4jQ6uutRaI28yxVarZN3zlRot4XNubBhfnTW\\\",\\\"expiry\\\":1709176154}}\""], ["updated_at", "2024-02-15 03:09:14.793293"], ["id", 66]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.05ms)
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 66], ["LIMIT", 1]]
+Completed 200 OK in 300ms (Views: 0.4ms | ActiveRecord: 7.0ms | Allocations: 3306)
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (0.8ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "21_lavonia.feest@bauch.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (0.7ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "21_lavonia.feest@bauch.test"], ["encrypted_password", "$2a$12$V/dJrf45wZ9lIM3NLKDBfeIKx/KINsXzcXVZhnvMNpPYStcjNsQBG"], ["name", "bm6d"], ["email", "21_lavonia.feest@bauch.test"], ["created_at", "2024-02-15 03:09:15.098897"], ["updated_at", "2024-02-15 03:09:15.098897"]]
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/auth/sign_in" for 127.0.0.1 at 2024-02-15 12:09:15 +0900
+Processing by DeviseTokenAuth::SessionsController#create as HTML
+  Parameters: {"name"=>"1rkae2o5rd79s41ao54nnlsmm2sz", "email"=>"foo", "password"=>"[FILTERED]"}
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+  [1m[36mUser Load (3.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."email" = $1 AND "users"."provider" = $2 LIMIT $3[0m  [["email", "foo"], ["provider", "email"], ["LIMIT", 1]]
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.05ms)
+Completed 401 Unauthorized in 4ms (Views: 0.2ms | ActiveRecord: 3.0ms | Allocations: 667)
+  [1m[36mTRANSACTION (7.3ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.8ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.0ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "22_arleen_block@lind.test"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.0ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "22_arleen_block@lind.test"], ["encrypted_password", "$2a$12$N01hroqM/Qd2yTO6UljXYOahPwfuwlyF9rGpeB8KvzEiibbmJ.sJC"], ["name", "8d78tgfrl0n"], ["email", "22_arleen_block@lind.test"], ["created_at", "2024-02-15 03:09:15.416464"], ["updated_at", "2024-02-15 03:09:15.416464"]]
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+Started POST "/api/v1/auth/sign_in" for 127.0.0.1 at 2024-02-15 12:09:15 +0900
+Processing by DeviseTokenAuth::SessionsController#create as HTML
+  Parameters: {"name"=>"jcjlggtwqe8og2x", "email"=>"22_arleen_block@lind.test", "password"=>"[FILTERED]"}
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."email" = $1 AND "users"."provider" = $2 LIMIT $3[0m  [["email", "22_arleen_block@lind.test"], ["provider", "email"], ["LIMIT", 1]]
+[31mUnpermitted parameter: :name[0m
+[31mUnpermitted parameter: :name[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.06ms)
+Completed 401 Unauthorized in 287ms (Views: 0.3ms | ActiveRecord: 1.3ms | Allocations: 850)
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Exists? (1.6ms)[0m  [1m[34mSELECT 1 AS one FROM "users" WHERE LOWER("users"."email") = LOWER($1) AND "users"."provider" = $2 LIMIT $3[0m  [["email", "23_yadira.hermiston@marvin-waelchi.example"], ["provider", "email"], ["LIMIT", 1]]
+  [1m[36mUser Create (1.4ms)[0m  [1m[32mINSERT INTO "users" ("uid", "encrypted_password", "name", "email", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"[0m  [["uid", "23_yadira.hermiston@marvin-waelchi.example"], ["encrypted_password", "$2a$12$t.F5mlrUVr53cVywaoV.NOPxIdfjQ2XKrXIclJgOLrTynMOu/0lpi"], ["name", "rwckrbwa33"], ["email", "23_yadira.hermiston@marvin-waelchi.example"], ["created_at", "2024-02-15 03:09:16.002792"], ["updated_at", "2024-02-15 03:09:16.002792"]]
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.1ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", "\"{\\\"GTWE_7jNDEwHmbtbwwSHvg\\\":{\\\"token\\\":\\\"$2a$04$7M1zPXJOuRDatxYuPV3BeeSWWvqqZZZuqWandLeP0tr.vszxInezK\\\",\\\"expiry\\\":1709176156,\\\"updated_at\\\":\\\"2024-02-15T03:09:16Z\\\"}}\""], ["updated_at", "2024-02-15 03:09:16.007438"], ["id", 69]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 69], ["LIMIT", 1]]
+Started DELETE "/api/v1/auth/sign_out" for 127.0.0.1 at 2024-02-15 12:09:16 +0900
+Processing by DeviseTokenAuth::SessionsController#destroy as HTML
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."uid" = $1 LIMIT $2[0m  [["uid", "23_yadira.hermiston@marvin-waelchi.example"], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (1.6ms)[0m  [1m[35mSAVEPOINT active_record_1[0m
+  [1m[36mUser Update (1.5ms)[0m  [1m[33mUPDATE "users" SET "tokens" = $1, "updated_at" = $2 WHERE "users"."id" = $3[0m  [["tokens", nil], ["updated_at", "2024-02-15 03:09:16.021245"], ["id", 69]]
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[35mRELEASE SAVEPOINT active_record_1[0m
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.03ms)
+Completed 200 OK in 9ms (Views: 0.2ms | ActiveRecord: 4.8ms | Allocations: 1299)
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 69], ["LIMIT", 1]]
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[31mROLLBACK[0m
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+Started DELETE "/api/v1/auth/sign_out" for 127.0.0.1 at 2024-02-15 12:09:16 +0900
+Processing by DeviseTokenAuth::SessionsController#destroy as HTML
+[active_model_serializers] Rendered ActiveModel::Serializer::Null with Hash (0.05ms)
+Completed 404 Not Found in 0ms (Views: 0.2ms | ActiveRecord: 0.0ms | Allocations: 368)
+  [1m[36mTRANSACTION (0.7ms)[0m  [1m[31mROLLBACK[0m

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -17,24 +17,22 @@ RSpec.describe "Api::V1::Articles" do
       # res = JSON.parse(response.body)
       res = response.parsed_body
       # binding.pry
-      aggregate_failures do
-        # httpsステータスが:ok(200)であることをテスト
-        expect(response).to have_http_status(:ok)
-        # expect(response).to have_http_status(200)は上記と同義
+      # httpsステータスが:ok(200)であることをテスト
+      expect(response).to have_http_status(:ok)
+      # expect(response).to have_http_status(200)は上記と同義
 
-        # レスポンスの長さが "3" であることをテスト
-        expect(res.length).to eq 3
+      # レスポンスの長さが "3" であることをテスト
+      expect(res.length).to eq 3
 
-        # 取得した配列のidがarticle3,article1,article2の順番であることをテスト
-        # expect(res.map {|d| d["id"] }).to eq [ccc_article3.id, aaa_article1.id, bbb_article2.id]
-        expect(res.pluck("id")).to eq [ccc_article3.id, aaa_article1.id, bbb_article2.id]
+      # 取得した配列のidがarticle3,article1,article2の順番であることをテスト
+      # expect(res.map {|d| d["id"] }).to eq [ccc_article3.id, aaa_article1.id, bbb_article2.id]
+      expect(res.pluck("id")).to eq [ccc_article3.id, aaa_article1.id, bbb_article2.id]
 
-        # articleのレスポンスのkeyがid,title,updated_at,userであることをテスト
-        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      # articleのレスポンスのkeyがid,title,updated_at,userであることをテスト
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
 
-        # articleのレスポンスと一生に生成されたuserのkeyがid,name,emailであることをテスト
-        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
-      end
+      # articleのレスポンスと一生に生成されたuserのkeyがid,name,emailであることをテスト
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
     end
   end
 
@@ -50,24 +48,22 @@ RSpec.describe "Api::V1::Articles" do
 
         res = response.parsed_body
 
-        aggregate_failures do
-          # httpsステータスが:ok(200)であることをテスト
-          expect(response).to have_http_status(:ok)
+        # httpsステータスが:ok(200)であることをテスト
+        expect(response).to have_http_status(:ok)
 
-          # subject で API を叩いた時点でできた article と、API のレスポンスの値が同じであることテスト
-          expect(res["id"]).to eq article.id
-          expect(res["title"]).to eq article.title
-          expect(res["body"]).to eq article.body
+        # subject で API を叩いた時点でできた article と、API のレスポンスの値が同じであることテスト
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
 
-          # be_presentはarticleにはupdated_atが存在することを期待するテスト
-          expect(res["updated_at"]).to be_present
+        # be_presentはarticleにはupdated_atが存在することを期待するテスト
+        expect(res["updated_at"]).to be_present
 
-          # subject で API を叩いた時点でできた user と、API のレスポンスの値が同じであることテスト
-          expect(res["user"]["id"]).to eq article.user.id
+        # subject で API を叩いた時点でできた user と、API のレスポンスの値が同じであることテスト
+        expect(res["user"]["id"]).to eq article.user.id
 
-          # 返ってきたユーザーのデータは、id,name,email の 3 つのデータを持つこと期待するテスト
-          expect(res["user"].keys).to eq ["id", "name", "email"]
-        end
+        # 返ってきたユーザーのデータは、id,name,email の 3 つのデータを持つこと期待するテスト
+        expect(res["user"].keys).to eq ["id", "name", "email"]
       end
     end
 
@@ -84,7 +80,7 @@ RSpec.describe "Api::V1::Articles" do
     # subject が叩かれると呼び出されると params をルーティング通りに articles_controller に渡す
     # params の値は let(:params){ {article: attributes_for(:article)} } で生成される
     # 渡す時に article という key に値を渡さないといけない
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     context "適切なパラメータを送信した場合" do
       let(:params) { { article: attributes_for(:article) } }
@@ -98,26 +94,26 @@ RSpec.describe "Api::V1::Articles" do
       # 後ろの current_user が呼び出されたら let(:current_user) { create(:user) } が呼び出され create される
       # 今回は before が使われているので it が走る前に処理が行われる
       # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-      before do
-        current_user_mock = instance_double(Api::V1::BaseApiController)
-        allow(current_user_mock).to receive(:current_user).and_return(current_user)
-      end
+      # before do
+      #   current_user_mock = instance_double(Api::V1::BaseApiController)
+      #   allow(current_user_mock).to receive(:current_user).and_return(current_user)
+      # end
+
+      let(:headers) { current_user.create_new_auth_token } # 2/15 追記
 
       it "記事のレコードが作成できる" do
-        aggregate_failures do
-          # API を叩いた後の Article の current_user の数が1個にかわったことをテスト
-          # Article と current_userの紐づけが出来ていることと user_id が current_user の id になっていることを意味している
-          expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
-          res = response.parsed_body
-          # res = JSON.parse(response.body)
+        # API を叩いた後の Article の current_user の数が1個にかわったことをテスト
+        # Article と current_userの紐づけが出来ていることと user_id が current_user の id になっていることを意味している
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = response.parsed_body
+        # res = JSON.parse(response.body)
 
-          # パラメータを送信した直後とレスポンスの整合を確認するテスト
-          expect(res["title"]).to eq params[:article][:title]
-          expect(res["body"]).to eq params[:article][:body]
+        # パラメータを送信した直後とレスポンスの整合を確認するテスト
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
 
-          # httpsステータスが:ok(200)であることをテスト
-          expect(response).to have_http_status(:ok)
-        end
+        # httpsステータスが:ok(200)であることをテスト
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -125,10 +121,11 @@ RSpec.describe "Api::V1::Articles" do
       let(:params) { attributes_for(:article) }
       let(:current_user) { create(:user) }
       # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-      before do
-        current_user_mock = instance_double(Api::V1::BaseApiController)
-        allow(current_user_mock).to receive(:current_user).and_return(current_user)
-      end
+      # before do
+      #   current_user_mock = instance_double(Api::V1::BaseApiController)
+      #   allow(current_user_mock).to receive(:current_user).and_return(current_user)
+      # end
+      let(:headers) { current_user.create_new_auth_token } # 2/15 追記
 
       it "エラーする" do
         expect { subject }.to raise_error(ActionController::ParameterMissing)
@@ -137,11 +134,12 @@ RSpec.describe "Api::V1::Articles" do
   end
 
   describe "PATCH /articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token } # 2/15 追記
 
     context "ログインユーザーが自身の記事を更新しようとする場合" do
       let(:article) { create(:article, user: current_user) }
@@ -163,10 +161,11 @@ RSpec.describe "Api::V1::Articles" do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token } # 2/15 追記
 
     context "ログインユーザーが自身の記事を削除しようとする場合" do
       let!(:article) { create(:article, user: current_user) }

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -18,13 +18,11 @@ RSpec.describe "Api/V1::Auth::Registrations" do
       it "header 情報を取得することができる" do
         subject
         header = response.header
-        aggregate_failures do
-          expect(header["access-token"]).to be_present
-          expect(header["client"]).to be_present
-          expect(header["expiry"]).to be_present
-          expect(header["uid"]).to be_present
-          expect(header["token-type"]).to be_present
-        end
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to be_present
+        expect(header["token-type"]).to be_present
       end
     end
 

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "Api::V1::Auth::Sessions" do
       it "ログインできる" do
         subject
         header = response
-
         # ログインする時に必要な情報として以下の3つが挙げられる
         # "access-token","uid","client"が存在することを確認するテスト
         expect(header["access-token"]).to be_present
@@ -31,20 +30,18 @@ RSpec.describe "Api::V1::Auth::Sessions" do
         subject
         res = response.parsed_body
         header = response
-        aggregate_failures do
-          # コンソールで response.parsed_body を打ち込むと
-          # => {"success"=>false, "errors"=>["Invalid login credentials. Please try again."]}
-          # と表示されたので errors が "Invalid login credentials. Please try again." を include(〜を含む) していることをテストした
-          expect(res["errors"]).to include "Invalid login credentials. Please try again."
+        # コンソールで response.parsed_body を打ち込むと
+        # => {"success"=>false, "errors"=>["Invalid login credentials. Please try again."]}
+        # と表示されたので errors が "Invalid login credentials. Please try again." を include(〜を含む) していることをテストした
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
 
-          # response の中に下記の3つが含まれていないので be_blank でテストした
-          expect(header["access-token"]).to be_blank
-          expect(header["uid"]).to be_blank
-          expect(header["client"]).to be_blank
+        # response の中に下記の3つが含まれていないので be_blank でテストした
+        expect(header["access-token"]).to be_blank
+        expect(header["uid"]).to be_blank
+        expect(header["client"]).to be_blank
 
-          # subject を打つと401と表示されたので同じ意味である :unauthorized を使いステータスをテストした
-          expect(response).to have_http_status(:unauthorized) # 401 でも可
-        end
+        # subject を打つと401と表示されたので同じ意味である :unauthorized を使いステータスをテストした
+        expect(response).to have_http_status(:unauthorized) # 401 でも可
       end
     end
 
@@ -56,14 +53,13 @@ RSpec.describe "Api::V1::Auth::Sessions" do
         subject
         res = response.parsed_body
         header = response
-        aggregate_failures do
-          # email の時と同様のため省略
-          expect(res["errors"]).to include "Invalid login credentials. Please try again."
-          expect(header["access-token"]).to be_blank
-          expect(header["uid"]).to be_blank
-          expect(header["client"]).to be_blank
-          expect(response).to have_http_status(:unauthorized) # 401 でも可
-        end
+
+        # email の時と同様のため省略
+        expect(res["errors"]).to include "Invalid login credentials. Please try again."
+        expect(header["access-token"]).to be_blank
+        expect(header["uid"]).to be_blank
+        expect(header["client"]).to be_blank
+        expect(response).to have_http_status(:unauthorized) # 401 でも可
       end
     end
   end


### PR DESCRIPTION
## 概要

- stub で作った仮実装を devise_token_auth の機能を反映した内容に修正

## 内容

- devise_token_auth のヘルパーメソッドをエイリアスを指定してそれぞれ反映
- articles_controller 特定の API を認証済のユーザー以外はアクセスできないようにする
- 上記内容をふまえて、spec ファイルを修正

## 補足

- spec ファイルを修正する際に、aggregate_failuresの設定を spec.helper.rb にしたにも関わらず使用していたのでついでに削除した